### PR TITLE
Added make option to specify log level when compiling library/tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@
 # the library's version
 VERSION:=0.8.6
 
-DTLS_SUPPORT ?= posix
+DTLS_SUPPORT   ?= posix
+LOG_LEVEL_DTLS ?= LOG_LEVEL_INFO
 
 # files and flags
 SOURCES = dtls.c dtls-crypto.c dtls-ccm.c dtls-hmac.c netq.c dtls-peer.c
@@ -25,7 +26,7 @@ SOURCES+= dtls-log.c
 SOURCES+= aes/rijndael.c ecc/ecc.c sha2/sha2.c $(DTLS_SUPPORT)/dtls-support.c
 OBJECTS:= $(SOURCES:.c=.o)
 # CFLAGS:=-Wall -pedantic -std=c99 -g -O2 -I. -I$(DTLS_SUPPORT)
-CFLAGS:=-Wall -std=c99 -g -O2 -I. -I$(DTLS_SUPPORT)
+CFLAGS:=-DLOG_LEVEL_DTLS=$(LOG_LEVEL_DTLS) -Wall -std=c99 -g -O2 -I. -I$(DTLS_SUPPORT)
 LIB:=libtinydtls.a
 LDFLAGS:=
 ARFLAGS:=cru

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,7 +13,8 @@
 #    Olaf Bergmann  - initial API and implementation
 #
 
-DTLS_SUPPORT ?= posix
+DTLS_SUPPORT   ?= posix
+LOG_LEVEL_DTLS ?= LOG_LEVEL_INFO
 
 # files and flags
 SOURCES:= dtls-server.c ccm-test.c prf-test.c dtls-client.c
@@ -23,7 +24,7 @@ LIB:=../libtinydtls.a
 
 OBJECTS := $(patsubst %.c, %.o, $(SOURCES))
 
-CFLAGS  := -I. -I.. -I../$(DTLS_SUPPORT)
+CFLAGS  := -DLOG_LEVEL_DTLS=$(LOG_LEVEL_DTLS) -I. -I.. -I../$(DTLS_SUPPORT)
 LDFLAGS := -L..
 LDLIBS  := -ltinydtls
 

--- a/tests/dtls-client.c
+++ b/tests/dtls-client.c
@@ -305,8 +305,7 @@ usage( const char *program, const char *version) {
 	  "\t-k file\t\tread pre-shared key from file\n"
 #endif /* DTLS_PSK */
 	  "\t-o file\t\toutput received data to this file (use '-' for STDOUT)\n"
-	  "\t-p port\t\tlisten on specified port (default is %d)\n"
-	  "\t-v num\t\tverbosity level (default: 3)\n",
+	  "\t-p port\t\tlisten on specified port (default is %d)\n",
 	   program, version, program, DEFAULT_PORT);
 }
 

--- a/tests/dtls-server.c
+++ b/tests/dtls-server.c
@@ -240,8 +240,7 @@ usage(const char *program, const char *version) {
 	  "(c) 2011-2014 Olaf Bergmann <bergmann@tzi.org>\n\n"
 	  "usage: %s [-A address] [-p port] [-v num]\n"
 	  "\t-A address\t\tlisten on specified address (default is ::)\n"
-	  "\t-p port\t\tlisten on specified port (default is %d)\n"
-	  "\t-v num\t\tverbosity level (default: 3)\n",
+	  "\t-p port\t\tlisten on specified port (default is %d)\n",
 	   program, version, program, DEFAULT_PORT);
 }
 


### PR DESCRIPTION
As reported in #2, the compile based logging that is now used by default is not runtime configurable.

Removed the command line argument to specify log level from tests/dtls-client and tests/dtls-server and instead added a make option to specify the log level when compiling:

```make
make LOG_LEVEL_DTLS=LOG_LEVEL_DBG
```