### PR TITLE
Added checks if a peer exists before using it

### DIFF
--- a/dtls-crypto.c
+++ b/dtls-crypto.c
@@ -34,7 +34,7 @@
 #include "lib/memb.h"
 
 /* Log configuration */
-#define LOG_MODULE "dtls-crypto"
+#define LOG_MODULE "dtls-crypt"
 #define LOG_LEVEL  LOG_LEVEL_DTLS
 #include "dtls-log.h"
 

--- a/netq.c
+++ b/netq.c
@@ -30,7 +30,7 @@
 #include "lib/memb.h"
 
 /* Log configuration */
-#define LOG_MODULE "netq"
+#define LOG_MODULE "dtls-netq"
 #define LOG_LEVEL  LOG_LEVEL_DTLS
 #include "dtls-log.h"
 


### PR DESCRIPTION
There seems to be some corner cases where a peer can be used when it does not exist. This adds checks that a valid peer exists before it is used.