### PR TITLE
rename ecc_ecdsa_sign to ecc_ecdsa_sign_hash 

### DIFF
--- a/dtls-crypto.c
+++ b/dtls-crypto.c
@@ -402,7 +402,7 @@ dtls_ecdsa_create_sig_hash(const unsigned char *priv_key, size_t key_size,
   dtls_ec_key_to_uint32(sign_hash, sign_hash_size, hash);
   do {
     dtls_fill_random((uint8_t *)rand, key_size);
-    ret = ecc_ecdsa_sign(priv, hash, rand, point_r, point_s);
+    ret = ecc_ecdsa_sign_hash(priv, hash, rand, point_r, point_s);
   } while (ret);
 }
 

--- a/ecc/ecc.c
+++ b/ecc/ecc.c
@@ -531,7 +531,7 @@ void ecc_ec_mult(const uint32_t *px, const uint32_t *py, const uint32_t *secret,
  *   0: everything is ok
  *  -1: can not create signature, try again with different k.
  */
-int ecc_ecdsa_sign(const uint32_t *d, const uint32_t *e, const uint32_t *k, uint32_t *r, uint32_t *s)
+int ecc_ecdsa_sign_hash(const uint32_t *d, const uint32_t *e, const uint32_t *k, uint32_t *r, uint32_t *s)
 {
 	uint32_t tmp1[16];
 	uint32_t tmp2[9];

--- a/ecc/ecc.h
+++ b/ecc/ecc.h
@@ -50,7 +50,7 @@ static inline void ecc_ecdh(const uint32_t *px, const uint32_t *py, const uint32
 	ecc_ec_mult(px, py, secret, resultx, resulty);
 }
 int ecc_ecdsa_validate(const uint32_t *x, const uint32_t *y, const uint32_t *e, const uint32_t *r, const uint32_t *s);
-int ecc_ecdsa_sign(const uint32_t *d, const uint32_t *e, const uint32_t *k, uint32_t *r, uint32_t *s);
+int ecc_ecdsa_sign_hash(const uint32_t *d, const uint32_t *e, const uint32_t *k, uint32_t *r, uint32_t *s);
 
 int ecc_is_valid_key(const uint32_t * priv_key);
 static inline void ecc_gen_pub_key(const uint32_t *priv_key, uint32_t *pub_x, uint32_t *pub_y)

--- a/ecc/tests/testecc.c
+++ b/ecc/tests/testecc.c
@@ -176,7 +176,7 @@ void ecdsaTest() {
 
 	ecc_ec_mult(BasePointx, BasePointy, ecdsaTestSecret, pub_x, pub_y);
 
-	ret = ecc_ecdsa_sign(ecdsaTestSecret, ecdsaTestMessage, ecdsaTestRand1, tempx, tempy);
+	ret = ecc_ecdsa_sign_hash(ecdsaTestSecret, ecdsaTestMessage, ecdsaTestRand1, tempx, tempy);
 	assert(ecc_isSame(tempx, ecdsaTestresultR1, arrayLength));
 	assert(ecc_isSame(tempy, ecdsaTestresultS1, arrayLength));
 	assert(ret == 0);
@@ -185,7 +185,7 @@ void ecdsaTest() {
 	assert(!ret);
 
 
-	ret = ecc_ecdsa_sign(ecdsaTestSecret, ecdsaTestMessage, ecdsaTestRand2, tempx, tempy);
+	ret = ecc_ecdsa_sign_hash(ecdsaTestSecret, ecdsaTestMessage, ecdsaTestRand2, tempx, tempy);
 	assert(ecc_isSame(tempx, ecdsaTestresultR2, arrayLength));
 	assert(ecc_isSame(tempy, ecdsaTestresultS2, arrayLength));
 	assert(ret == 0);


### PR DESCRIPTION
to prevent collision with ccxxxxware

see https://github.com/contiki-ng/contiki-ng/issues/628